### PR TITLE
[v2]Update: bulma in bootstrap out

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,8 @@ gem 'jbuilder', '~> 2.7'
 # gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.4.4', require: false
+#gem 'bootsnap', '>= 1.4.4', require: false
+gem "bulma-rails", "~> 0.9.3"
 
 # Japanese localization
 gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,8 +75,6 @@ GEM
     bindex (0.8.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
-    bootsnap (1.11.1)
-      msgpack (~> 1.2)
     bootstrap (5.1.3)
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 2.9.3, < 3)
@@ -85,6 +83,8 @@ GEM
     bullet (7.0.1)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
+    bulma-rails (0.9.3)
+      sassc (~> 2.0)
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
@@ -130,7 +130,6 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.15.0)
-    msgpack (1.5.1)
     nio4r (2.5.8)
     nokogiri (1.13.5-x86_64-darwin)
       racc (~> 1.4)
@@ -280,9 +279,9 @@ DEPENDENCIES
   annotate
   better_errors
   binding_of_caller
-  bootsnap (>= 1.4.4)
   bootstrap (~> 5.1, >= 5.1.3)
   bullet
+  bulma-rails (~> 0.9.3)
   byebug
   faker
   html2slim


### PR DESCRIPTION
# **概要**
CSSフレームワークをbootstrapからbulmaに変更。

# **影響範囲**
View

# **確認方法**
Gem を追加したので `bundle install` を実行してください

# **チェックリスト**

- [ ]  Gemfile.lockの確認

# **コメント**
小沼さんとの技術面談により変更