### PR TITLE
おやつモデルにimageカラムを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'jbuilder', '~> 2.7'
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 
+# --- Add Gems ---
 # Reduces boot times through caching; required in config/boot.rb
 gem "bulma-rails", "~> 0.9.3"
 
@@ -38,6 +39,10 @@ gem 'html2slim'
 
 # Page nation
 gem 'kaminari'
+
+# Image
+# gem 'carrierwave', '~> 2.2', '>= 2.2.2'
+gem 'mini_magick', '~> 4.11'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     method_source (1.0.0)
+    mini_magick (4.11.0)
     mini_mime (1.1.2)
     minitest (5.15.0)
     nio4r (2.5.8)
@@ -288,6 +289,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   kaminari
   listen (~> 3.3)
+  mini_magick (~> 4.11)
   nokogiri (~> 1.13, >= 1.13.6)
   pg (~> 1.1)
   puma (~> 5.0)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,6 +61,9 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  # アセットパイプラインへの画像追加
+  config.assets.compile = true
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/db/migrate/20220513052057_add_image_to_oyatsus.rb
+++ b/db/migrate/20220513052057_add_image_to_oyatsus.rb
@@ -1,0 +1,5 @@
+class AddImageToOyatsus < ActiveRecord::Migration[6.1]
+  def change
+    add_column :oyatsus, :image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_09_132953) do
+ActiveRecord::Schema.define(version: 2022_05_13_052057) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2022_05_09_132953) do
     t.integer "price", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "image"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
# **概要**
おやつモデルにimageカラムを追加

# **影響範囲**

- oyatsuモデル
- db/schema

# **確認方法**

1. カラムを追加したので `bundle exec rails db:migrate` を実行してください

# **チェックリスト**

- [ ] 対応するIssueを作成した
- [ ] Lint のチェックをパスした
- [ ] 確認方法の内容を満たした

# **コメント**

アップロード機能に関しては今回対応しないことにする。
別イシューを切って対応。