### PR TITLE
トップ画面を変更

### DIFF
--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -1,7 +1,12 @@
-section.hero.is-info.is-fullheight
+section.hero.is-info.is-medium
   div.hero-body
-    div.container.has-text-centered
-      p.title
-        Fullheight hero
-      p.subtitle">
-        Fullheight subtitle
+    div.container
+      p.title.has-text-centered あそびかた！
+      div.has-text-centered
+        ul
+          li 1. おかしをえらんでね。
+          p すきなおかしをクリックしよう！
+          li 2. いくつ買うかえらんでね。
+          p 300円まで買えるよ。
+          li 3. きまったらレジにいこう。
+/      = form_with model: @user, scope: post, url: 'choose_oyatsu_path'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   get 'users/index'
   get 'users/show'
-  get '/top', to: 'users#new'
-  root 'oyatsus#index'
+  root 'users#new'
+  get '/choose_oyatsu', to: 'oyatsus#index'
   get 'baskets/index'
   get 'oyatsus/index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
# **概要**

サービスのトップ画面をユーザー登録と使い方画面に変更。

# **影響範囲**

- config/routes.rb
- app/viewのuserとoyatsu
- app/contorllerのuserとoyatsu


# **確認方法**

1.  http://localhost:3000にアクセスしてtop画面を確認
2. http://localhost:3000/choose_oyatsuにアクセスしておやつ選択画面を確認

# **チェックリスト**

- [x] 対応するIssueを作成した
- [x] Lint のチェックをパスした
- [x] 確認方法の内容を満たした

# **コメント**

後日修正予定。