### PR TITLE
ユーザー入力画面とユーザーコントローラーの作成

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,10 +1,27 @@
+# User
 class UsersController < ApplicationController
-  def index
-  end
+  def index; end
 
-  def show
-  end
+  def show; end
 
   def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+
+    if @user.save
+      redirect_to choose_oyatsu_path, success: t('.success')
+    else
+      flash.now[:danger] = t('.failed')
+      render 'new'
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_many :baskets
 
+  validates :name, presence: true, length: { maximum: 128 }
   validates :comment, length: { maximum: 65_535 }
 end

--- a/app/views/oyatsus/index.html.slim
+++ b/app/views/oyatsus/index.html.slim
@@ -1,4 +1,4 @@
-div.hero.is-info.has-text-centered のこりのおこづかい:  おかいけい
+div.hero.is-info.has-text-centered #{User.first.name}のおこづかい:  おかいけい
 
 - if @oyatsus.present?
   = render @oyatsus

--- a/app/views/shared/_error_messages.html.slim
+++ b/app/views/shared/_error_messages.html.slim
@@ -1,0 +1,5 @@
+div.notification.is-danger  id='error_explanation'
+  .ul
+    - object.errors.full_messages.each do |message|
+      .li
+        = message

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -1,12 +1,26 @@
 section.hero.is-info.is-medium
   div.hero-body
-    div.container
-      p.title.has-text-centered あそびかた！
-      div.has-text-centered
-        ul
-          li 1. おかしをえらんでね。
-          p すきなおかしをクリックしよう！
-          li 2. いくつ買うかえらんでね。
-          p 300円まで買えるよ。
-          li 3. きまったらレジにいこう。
-/      = form_with model: @user, scope: post, url: 'choose_oyatsu_path'
+    div.section
+      div.container.is-max-desktop
+        p.title.has-text-centered おなまえをいれてね！
+        = form_with model: @user, local: true do |f|
+          - if @user.errors.any?
+            = render 'shared/error_messages', object: f.object
+          div.field
+            label.label.has-text-centered
+              = f.label :name, 'おなまえ'
+            div.control
+              = f.text_field :name, id: 'name', class: 'input is-large is-round is-half'
+          div.field.has-text-centered
+            div.control
+              = f.submit 'えらぶ', class: 'button is-link is-large is-round'
+    div.section
+      div.container
+        p.subtitle.has-text-centered あそびかた！
+        div.has-text-centered
+          ul
+            li 1. おかしをえらんでね。
+            p すきなおかしをクリックしよう！
+            li 2. いくつ買うかえらんでね。
+            p 300円まで買えるよ。
+            li 3. きまったらレジにいこう。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,9 @@
 Rails.application.routes.draw do
-  get 'users/index'
-  get 'users/show'
   root 'users#new'
   get '/choose_oyatsu', to: 'oyatsus#index'
   get 'baskets/index'
   get 'oyatsus/index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
-  resources :users, only: %i[new create]
+  resources :users, only: %i[index show create]
 end

--- a/db/migrate/20220513092420_add_genre_to_oyatsus.rb
+++ b/db/migrate/20220513092420_add_genre_to_oyatsus.rb
@@ -1,5 +1,5 @@
 class AddGenreToOyatsus < ActiveRecord::Migration[6.1]
   def change
-    add_column :oyatsus, :genre, :string
+    add_column :oyatsus, :genre, :string, null: false
   end
 end

--- a/db/migrate/20220516091328_add_name_to_users.rb
+++ b/db/migrate/20220516091328_add_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddNameToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_13_092420) do
+ActiveRecord::Schema.define(version: 2022_05_16_091328) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2022_05_13_092420) do
     t.string "comment"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "name"
   end
 
   add_foreign_key "baskets", "oyatsus"


### PR DESCRIPTION
# **概要**

ユーザー入力画面を追加しました。

# **影響範囲**

- ルーティング
- userモデル
- userコントローラー

# **確認方法**

1. localhost:3000にアクセス
2. ユーザー名を追加
3. えらぶを押下
4. 画面遷移を確認

# **チェックリスト**

- [ ] 対応するIssueを作成した
- [ ] Lint のチェックをパスした
- [ ] 確認方法の内容を満たした

# **コメント**

ページ間の情報連携が出来ていないので、裏でセッション機能を走らせることにする。