### PR TITLE
買い物カゴにおかしを追加する処理の修正

### DIFF
--- a/app/controllers/baskets_controller.rb
+++ b/app/controllers/baskets_controller.rb
@@ -5,6 +5,10 @@ class BasketsController < ApplicationController
     @baskets = Basket.where(user_id: params[:user_id])
   end
 
+  def new
+    @basket = Basket.new
+  end
+
   def create
     @basket = Basket.new(basket_params)
     @basket.user_id = current_user.id
@@ -28,6 +32,6 @@ class BasketsController < ApplicationController
   end
 
   def basket_params
-    params.require(:basket, :oyatsu).permit(:quantity, :oyatsu_id)
+    params.require(:basket).permit(:quantity, :oyatsu_id)
   end
 end

--- a/app/views/oyatsus/_basket.html.slim
+++ b/app/views/oyatsus/_basket.html.slim
@@ -2,7 +2,8 @@ div.hero.is-info
   div.hero-body.has-text-centered
     - calculation
     div.section
-      div.title  #{current_user.name}の残りのおこづかい: #{current_user.purse}
+      div.title  残りのおこづかい: #{current_user.purse}
+      div.subtitle #{current_user.name}の買い物かご
       - if current_user.baskets.present?
         = render 'oyatsus/basket_oyatsu', {basket_oyatsus: current_user.baskets}
         - current_user.baskets.each do |b|
@@ -11,6 +12,6 @@ div.hero.is-info
     div.section
       - if current_user.purse.negative?
         div.title あれれ、おかねがたりないみたい
-          div.subtitle もういちどえらびなおそう！
+        div.subtitle もういちどえらびなおそう！
       - else
           = link_to 'レジ', user_baskets_path(current_user.id), class: 'button'

--- a/app/views/oyatsus/_oyatsu.html.slim
+++ b/app/views/oyatsus/_oyatsu.html.slim
@@ -8,7 +8,7 @@ div.modal id="modal-js-#{oyatsu.id}"
       = image_tag "download_images/#{oyatsu.genre}/#{oyatsu.image_url.split('/').last}" 
       p.has-text-centered #{oyatsu.price}円
     footer.modal-card-foot
-      = form_with url: '/baskets', method: 'post', local: true do |f|
+      = form_with model: Basket.new, url: user_baskets_path(oyatsu.id), method: 'post', local: true do |f|
         div.field
           label.label
             = f.label :quantity, 'こすう'


### PR DESCRIPTION
# **概要**

買い物カゴに正しくおかしを追加できないエラーを修正。

# **影響範囲**

- app/controller/basekt_controller
- app/view/oyatsu以下

# **確認方法**

1. おやつ選択画面からおやつを選択して買い物カゴに追加できることを確認。

# **チェックリスト**

- [x] 対応するIssueを作成した
- [x] Lint のチェックをパスした
- [x] 確認方法の内容を満たした

# **コメント**
特になし。